### PR TITLE
fix error on redis-cli --eval redimension.lua

### DIFF
--- a/redimension.lua
+++ b/redimension.lua
@@ -300,7 +300,7 @@ end
 
 -- parse arguments
 if #ARGV == 0 or #KEYS ~= 2 then
-  return(_commands)
+  return(_USAGE)
 end
 
 local cmd = ARGV[1]:lower()


### PR DESCRIPTION
change undeclared _command to _USAGE
this error raised when uses redimension in redis-cli --eval
# example
- redis-cli --eval redimension.lua z h , drop
- redis-cli --eval redimension.lua z h , create 2 32
